### PR TITLE
Set up SSL in production and update Docker configuration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,6 @@ WORKDIR /app
 
 COPY --from=build /app/target/solesonic-mcp-server-0.0.1-SNAPSHOT.jar app.jar
 
-EXPOSE 8081
+EXPOSE 9443
 
-ENTRYPOINT ["java", "-jar", "app.jar", "--server.port=8081"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,4 +13,4 @@ services:
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD}
     volumes:
       - ${SYSTEM_SSL_CERT_LOCATION}/${SSL_CERT_FILE}:/run/secrets/${SSL_CERT_FILE}:ro
-    restart: unless-stopped
+    restart: no

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,8 +9,10 @@ services:
     env_file:
       - .env
     environment:
+      - SPRING_PROFILES_ACTIVE=prod
       - SSL_CERT_LOCATION=/run/secrets/${SSL_CERT_FILE}
       - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD}
+      - SERVER_PORT=9443
     volumes:
       - ${SYSTEM_SSL_CERT_LOCATION}/${SSL_CERT_FILE}:/run/secrets/${SSL_CERT_FILE}:ro
     restart: no

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,9 +5,12 @@ services:
       dockerfile: docker/Dockerfile
     container_name: solesonic-mcp-server
     ports:
-      - "8081:8081"
+      - "9443:9443"
     env_file:
-      - ../.env
+      - .env
     environment:
-      - SERVER_PORT=8081
+      - SSL_CERT_LOCATION=/run/secrets/${SSL_CERT_FILE}
+      - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD}
+    volumes:
+      - ${SYSTEM_SSL_CERT_LOCATION}/${SSL_CERT_FILE}:/run/secrets/${SSL_CERT_FILE}:ro
     restart: unless-stopped

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,7 @@
+server.port=${SERVER_PORT:9443}
+server.ssl.key-store=file:${SSL_CERT_LOCATION}
+server.ssl.key-store-type=PKCS12
+server.ssl.key-alias=tomcat
+server.ssl.key-store-password=${KEYSTORE_PASSWORD}
+server.ssl.enabled-protocols=TLSv1.2,TLSv1.3
+server.ssl.ciphers=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=solesonic-mcp-server
 
-server.port=8081
+server.port=9443
 
 spring.ai.mcp.server.name=solesonic-mcp-server
 spring.ai.mcp.server.version=1.0.0


### PR DESCRIPTION
```
### Description of Changes

- Configured `SPRING_PROFILES_ACTIVE` to `prod` for consistent environment setup.
- Updated `SERVER_PORT` and port configurations to `9443` for secure HTTPS communication.
- Disabled container restart policy in Docker Compose configuration for better control during development.
- Enabled SSL in production, ensuring HTTPS usage on port 9443.
- Expanded `README` with detailed steps on SSL configuration and deployment.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [x] Documentation update

```