### PR TITLE
Expand weather authority checks and migrate DCR to in-app endpoints

### DIFF
--- a/src/main/java/com/solesonic/mcp/service/WeatherService.java
+++ b/src/main/java/com/solesonic/mcp/service/WeatherService.java
@@ -12,7 +12,7 @@ public class WeatherService {
 
     @SuppressWarnings("unused")
     @Tool(description = "Returns the weather in the given city.", name = "weather_lookup")
-    @PreAuthorize("hasAuthority('GROUP_MCP-GET-WEATHER')")
+    @PreAuthorize("hasAuthority('GROUP_MCP-GET-WEATHER') or hasAuthority('SCOPE_izzy-bot-mcp-server/mcp-execute')")
     public String weatherLookup(String city, ToolContext toolContext) {
         log.info("Received request for weather in {}", city);
 


### PR DESCRIPTION
### Description

- Updated weather authority checks to include scope claims in addition to groups for improved JWT authority extraction logic.
- Migrated Dynamic Client Registration (DCR) from AWS facade to Spring Boot in-app endpoints for managing Cognito client lifecycle.

### Scope of Changes

- Refined authority extraction logic.
- Introduced Spring Boot endpoints for DCR to replace AWS facade integration. 

### Testing

- Ensure updates to authority checks work seamlessly with varied JWT structures.
- Verify the new in-app DCR endpoints function correctly in managing the Cognito client lifecycle.
